### PR TITLE
Rust: Reduce verbosity of the example code

### DIFF
--- a/rust-cargo/src/main.rs
+++ b/rust-cargo/src/main.rs
@@ -1,34 +1,35 @@
 extern crate sdl2;
 extern crate native;
 
+use sdl2::timer;
+use sdl2::render::Renderer;
+use sdl2::render;
+use sdl2::surface::Surface;
+use sdl2::video::Window;
+use sdl2::video;
+
 fn main() {
     sdl2::init(sdl2::InitEverything);
 
-    let win = match sdl2::video::Window::new("Hello World!", sdl2::video::Positioned(100), sdl2::video::Positioned(100), 960, 540, sdl2::video::Shown) {
-        Ok(window) => window,
-        Err(err) => fail!(format!("SDL_CreateWindow Error: {}", err))
-    };
+    let win = Window::new("Hello World!",
+                          video::Positioned(100),
+                          video::Positioned(100),
+                          960, 540,
+                          video::Shown).unwrap();
 
-    let ren = match sdl2::render::Renderer::from_window(win, sdl2::render::DriverAuto, sdl2::render::Accelerated) {
-        Ok(renderer) => renderer,
-        Err(err) => fail!(format!("SDL_CreateRenderer Error: {}", err))
-    };
+    let ren = Renderer::from_window(win,
+                                    render::DriverAuto,
+                                    render::Accelerated).unwrap();
 
-    let bmp = match sdl2::surface::Surface::from_bmp(&Path::new("../img/boxes.bmp")) {
-    	Ok(bmp) => bmp,
-	Err(err) => fail!(format!("SDL_LoadBMP Error: {}", err))
-    };
+    let bmp = Surface::from_bmp(&Path::new("../img/boxes.bmp")).unwrap();
 
-    let tex = match ren.create_texture_from_surface(&bmp) {
-    	Ok(tex) => tex,
-	Err(err) => fail!(format!("SDL_CreateTextureFromSurface Error: {}", err))
-    };
+    let tex = ren.create_texture_from_surface(&bmp).unwrap();
 
     let _ = ren.clear();
     let _ = ren.copy(&tex, None, None);
     ren.present();
 
-    sdl2::timer::delay(2000);
+    timer::delay(2000);
 
     sdl2::quit();
 }


### PR DESCRIPTION
Yes, this style is common among rusticians. Also, rust-sdl2 currently requires cargo.
