### PR TITLE
Updated the Ada example to use Alire.

### DIFF
--- a/ada/.gitignore
+++ b/ada/.gitignore
@@ -1,0 +1,4 @@
+/obj/
+/bin/
+/alire/
+/config/

--- a/ada/README.md
+++ b/ada/README.md
@@ -1,8 +1,26 @@
 ## Requirements
 
-- Ada compiler
-- SDLAda binding to SDL2, SDL2_image, and SDL2_ttf
-- GPRbuild
+* If you can use Alire ([here](https://ada-lang.io) and [here](https://alire.ada.dev/docs/)), then it should meet all the requirements (but see macOS notes below).
+* If not,
+  - Ada compiler
+  - SDLAda binding to SDL2 and SDL2\_image
+  - GPRbuild
+
+## Build with Alire ##
+
+Once `alr` is installed, just `alr build`. This will, as necessary, download a compiler, the build tool gprbuild, SDLada, and external libraries (SDL2 and SDL2\_image; also, but not used in this example, SDL\_mixer and SDL\_ttf), and then proceed to build the example (in `bin/main`).
+
+### macOS ###
+
+This suite (and SDLada) aren't written to use the framework SDL2 libraries.  A sufficiently recent `alr` will install external libraries using either [Homebrew](https://brew.sh) or [MacPorts](https://www.macports.org).
+
+### macOS on Intel silicon ###
+
+To get a "sufficiently recent" `alr`, visit the [v2.0.0-beta1](https://github.com/alire-project/alire/releases/tag/v2.0.0-beta1) or [nightly](https://github.com/alire-project/alire/releases/tag/nightly) releases.
+
+### macOS on Apple silicon ###
+
+Because the package managers will install `aarch64` (`arm64`) binaries when run on Apple silicon, you'll need to use an `aarch64` toolchain (`alr` and the compiler). These aren't (yet) available from the official Alire repositories, but they are available [here](https://github.com/simonjwright/alire-index.mac).
 
 ## Build on Arch Linux
 
@@ -13,21 +31,6 @@ Then just:
 
     gprbuild -largs $(pkg-config sdl2 SDL_image --libs)
 
-## Build on macOS
-
-Previously, these steps worked:
-
-* Change `sdlada` to `SDLAda` in `main.gpr`.
-* SDL2 and SDL2_image must be installed in `/Library/Frameworks`.
-
-Then just:
-
-    gprbuild -largs -F/Library/Frameworks -framework SDL2 -framework SDL2_image
-
-But now it seems like Alire is the way to go:
-
-* https://alire.ada.dev/
-
-However, I could not find a way to build this example with Alire, yet (on an M2 mac).
+----
 
 Pull requests are welcome.

--- a/ada/alire.toml
+++ b/ada/alire.toml
@@ -1,0 +1,16 @@
+name = "main"
+description = "Ada example for SDL2"
+version = "0.1.0-dev"
+
+authors = ["Alexander F. Rødseth"]
+maintainers = ["Simon Wright <simon@pushface.org>"]
+maintainers-logins = ["xyproto", "simonjwright"]
+licenses = "BSD-3-Clause"
+website = ""
+tags = ["sdl2", "ada", "example"]
+
+executables = ["main"]
+project-files = ["main.gpr"]
+
+[[depends-on]]
+sdlada = "^2.0.0"

--- a/ada/main.gpr
+++ b/ada/main.gpr
@@ -1,5 +1,17 @@
 with "sdlada";
+with "config/ada_example_config.gpr";
 
 project Main is
    for Main use ("main.adb");
+   for Source_Dirs use ("src");
+   for Object_Dir use "obj";
+   for Exec_Dir use "bin";
+
+   package Compiler is
+      for Switches ("ada") use Ada_Example_Config.Ada_Compiler_Switches;
+   end Compiler;
+
+   package Linker is
+      for Switches ("ada") use ("-g", "-lSDL2", "-lSDL2_image");
+   end Linker;
 end Main;

--- a/ada/src/main.adb
+++ b/ada/src/main.adb
@@ -3,7 +3,7 @@ with Ada.Command_Line;
 
 with SDL.Video.Windows.Makers;
 with SDL.Video.Renderers.Makers;
-with SDL.Video.Surfaces.Makers;
+with SDL.Video.Surfaces;
 with SDL.Video.Textures.Makers;
 
 with SDL.Images.IO;
@@ -16,8 +16,7 @@ procedure Main is
    Image_Name   : constant String := "../img/grumpy-cat.png";
 
    use SDL.Video;
-   use type Windows.Window_Flags;
-   use type Renderers.Renderer_flags;
+   use type Renderers.Renderer_Flags;
    use type SDL.Events.Event_Types;
 
    Win : Windows.Window;
@@ -31,7 +30,7 @@ procedure Main is
 begin
 
    --  Initialise SDL
-   if not SDL.Initialise or not SDL.Images.Initialise then
+   if not SDL.Initialise or else not SDL.Images.Initialise then
       Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error,
                             "SDL.Initialize error: " & SDL.Error.Get);
       Ada.Command_Line.Set_Exit_Status (Ada.Command_Line.Failure);


### PR DESCRIPTION
Alire supports various linuxes, windows and macOS (I'm not sure about arch linux, work is definitely in progress).

I put myself in as maintainer in alire.toml; they do require an email address for the 'maintainers' table, but since it's quite unlikely (?) we'll want to release an Alire crate for this example it may not matter.

You may want to move main.adb and the executable back to ada/.

  * ada/.gitignore: ignore alire-related directories.
  * ada/README.md: updated for Alire.
  * ada/alire.toml: new.
  * ada/main.gpr: added Alire-related options.
  * ada/src/main.adb: renamed from ada/main.adb. Tidied up compiler warnings generated in Alire's 'development' profile.